### PR TITLE
Fixed DateTimeUtilsTest so that it works in non-GMT timezones

### DIFF
--- a/src/test/java/com/autonomy/aci/client/util/DateTimeUtilsTest.java
+++ b/src/test/java/com/autonomy/aci/client/util/DateTimeUtilsTest.java
@@ -8,6 +8,7 @@ package com.autonomy.aci.client.util;
 import org.junit.Test;
 
 import java.text.ParseException;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 
@@ -20,7 +21,10 @@ public class DateTimeUtilsTest {
 
     private final String dateString = "12 Mar 09 16:48:27";
 
-    private final Date dateDate = new Date(1236876507000L);
+    private final Date dateDate = new Calendar.Builder()
+            .setDate(2009, Calendar.MARCH, 12)
+            .setTimeOfDay(16, 48, 27, 0)
+            .build().getTime();
 
     @Test
     public void testParseDate() throws ParseException {


### PR DESCRIPTION
Fixed DateTimeUtilsTest#testParseDate so that it works in timezones other than GMT. The current test used hard-coded time in milliseconds for dateDate. When run in locations other than GMT, this led to failures as the milliseconds were interpreted in the local timezone. Using Calendar Builder generates the date in the local timezone (the same way that it is parsed).